### PR TITLE
Escape  in json patch keys

### DIFF
--- a/controller/webhook.go
+++ b/controller/webhook.go
@@ -357,7 +357,7 @@ func updateAnnotations(target map[string]string, annotations map[string]string) 
 		}
 		patch = append(patch, PatchOperation{
 			Op:    op,
-			Path:  "/metadata/annotations/" + key,
+			Path:  "/metadata/annotations/" + strings.ReplaceAll(key, "/", "~1"),
 			Value: value,
 		})
 	}


### PR DESCRIPTION
Issue #, if available: None

Description of changes:

I realized that we often have keys with `/` character, which means adding the key directly to the path will result in errors. I've used guidance from https://datatracker.ietf.org/doc/html/rfc6901#section-3 and escaped the character to ~1. I tested this by running the controller in my dev k8s env and using it to inject the proxy into a test instance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.