### PR TITLE
Changes github workflows to use a newer version of go

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.14.0'
+          go-version: ~1.19.1
 
       - name: Build
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode/*
 .DS_Store
+aws-signingproxy-admissioncontroller


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
- We have some dependabot PRs that fail because we're using an old go version in the workflows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.