### PR TITLE
Changes github actions to only run on PR and push to master branch

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -1,6 +1,12 @@
 name: CD
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:
@@ -18,5 +24,6 @@ jobs:
         run: |
           go get -d -v
           go build -v .
+
       - name: Run tests
         run: go test -v ./...


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
- Changes github actions to only run on PR and push to master branch
- This is to avoid multiple github action workflows being run when a PR is created

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.