### PR TITLE
chore: Migrate Helm chart from the `eks-chart` repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,7 @@ The mutation admission controller will inject the [AWS SIGv4 Proxy](https://gith
 
 ## Getting Started
 
-A helm chart exists to deploy all the resources needed to use the admission controller here: https://github.com/aws/eks-charts/tree/master/stable/aws-sigv4-proxy-admission-controller/.
-
-### Installing the Controller via Helm Chart
-
-Add the EKS repository to Helm:
-
-```bash
-helm repo add eks https://aws.github.io/eks-charts
-```
-
-Install the AWS SIGv4 Admission Controller chart with default configuration:
-
-```bash
-helm install aws-sigv4-proxy-admission-controller eks/aws-sigv4-proxy-admission-controller --namespace <namespace>
-```
-
-### Uninstalling the Helm Chart
-
-To uninstall/delete the `aws-sigv4-proxy-admission-controller` release:
-
-```bash
-helm uninstall aws-sigv4-proxy-admission-controller --namespace <namespace>
-```
+See the [Helm chart](./helm/aws-sigv4-proxy-admission-controller/) for instructions on how to install the AWS SIGv4 Proxy Admission Controller using Helm.
 
 ### Doing It Yourself
 

--- a/helm/aws-sigv4-proxy-admission-controller/.helmignore
+++ b/helm/aws-sigv4-proxy-admission-controller/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/aws-sigv4-proxy-admission-controller/Chart.yaml
+++ b/helm/aws-sigv4-proxy-admission-controller/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+name: aws-sigv4-proxy-admission-controller
+description: AWS SIGv4 Admission Controller Helm Chart for Kubernetes
+version: 0.1.2
+appVersion: 1.0
+home: https://github.com/aws/eks-charts
+icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
+sources:
+  - https://github.com/aws/eks-charts
+maintainers:
+  - name: AWS Observability Team
+    url: https://github.com/aws-observability

--- a/helm/aws-sigv4-proxy-admission-controller/README.md
+++ b/helm/aws-sigv4-proxy-admission-controller/README.md
@@ -1,0 +1,45 @@
+# AWS SIGv4 Admission Controller
+
+A helm chart for [AWS SIGv4 Admission Controller](https://github.com/aws-observability/aws-sigv4-proxy-admission-controller)
+
+## Installing the Chart
+
+Add the EKS repository to Helm:
+
+```bash
+# TODO - update with Public ECR repository
+helm repo add eks https://aws.github.io/eks-charts
+```
+
+Install the AWS SIGv4 Admission Controller chart with default configuration:
+
+```bash
+# TODO - update with Public ECR repository
+helm install aws-sigv4-proxy-admission-controller eks/aws-sigv4-proxy-admission-controller --namespace <namespace>
+```
+
+## Uninstalling the Chart
+
+To uninstall/delete the `aws-sigv4-proxy-admission-controller` release:
+
+```bash
+# TODO - update with Public ECR repository
+helm uninstall aws-sigv4-proxy-admission-controller --namespace <namespace>
+```
+
+## Configuration
+
+| Parameter | Description | Default
+| - | - | -
+| `nameOverride` | Used to override name of chart | `""`
+| `fullnameOverride` | Used to override the full name of the application | `""`
+| `replicaCount` | Number of replicas | `1`
+| `image.repository` | Repository of image to pull for deployment | `public.ecr.aws/aws-observability/aws-sigv4-proxy-admission-controller`
+| `image.tag` | Tag of image to pull from repository | `1.0`
+| `image.pullPolicy` | Policy of how to pull image | `IfNotPresent`
+| `env.awsSigV4ProxyImage` | Image URI of sidecar container for AWS SIGv4 Proxy | `public.ecr.aws/aws-observability/aws-sigv4-proxy:1.0`
+| `serviceAccount.create` | Whether to create a service account or not | `true`
+| `serviceAccount.name` | The name of the service account to create or use | `""`
+| `rbac.create` | Whether to create rbac resources or not | `true`
+| `webhookService.port` | Incoming port used by webhook service | `443`
+| `webhookService.targetPort` | Target port used by webhook service | `443`

--- a/helm/aws-sigv4-proxy-admission-controller/templates/NOTES.txt
+++ b/helm/aws-sigv4-proxy-admission-controller/templates/NOTES.txt
@@ -1,0 +1,2 @@
+{{ .Release.Name }} has been installed or updated. To check the status of pods, run:
+kubectl get pods -n {{ .Release.Namespace }}

--- a/helm/aws-sigv4-proxy-admission-controller/templates/_helpers.tpl
+++ b/helm/aws-sigv4-proxy-admission-controller/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "aws-sigv4-proxy-admission-controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "aws-sigv4-proxy-admission-controller.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "aws-sigv4-proxy-admission-controller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "aws-sigv4-proxy-admission-controller.labels" -}}
+helm.sh/chart: {{ include "aws-sigv4-proxy-admission-controller.chart" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "aws-sigv4-proxy-admission-controller.serviceAccountName" -}}
+  {{ default (include "aws-sigv4-proxy-admission-controller.fullname" .) .Values.serviceAccount.name }}
+{{- end -}}
+
+{{/*
+Generate certificates for webhook
+*/}}
+{{- define "aws-sigv4-proxy-admission-controller.gen-certs" -}}
+{{- $fullName := ( include "aws-sigv4-proxy-admission-controller.fullname" . ) -}}
+{{- $serviceName := ( printf "%s-%s" $fullName "webhook-service" ) -}}
+{{- $altNames := list ( printf "%s.%s" $serviceName .Release.Namespace ) ( printf "%s.%s.svc" $serviceName .Release.Namespace ) -}}
+{{- $ca := genCA "aws-sigv4-proxy-admission-controller-ca" 3650 -}}
+{{- $cert := genSignedCert $fullName nil $altNames 3650 $ca -}}
+caCert: {{ $ca.Cert | b64enc }}
+clientCert: {{ $cert.Cert | b64enc }}
+clientKey: {{ $cert.Key | b64enc }}
+{{- end -}}

--- a/helm/aws-sigv4-proxy-admission-controller/templates/deployment.yaml
+++ b/helm/aws-sigv4-proxy-admission-controller/templates/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-webhook-deployment
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}
+{{ include "aws-sigv4-proxy-admission-controller.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}
+    spec:
+      serviceAccountName: {{ template "aws-sigv4-proxy-admission-controller.serviceAccountName" . }}
+      containers:
+        - name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - -tlsCertFile=/etc/webhook/certs/cert.pem
+            - -tlsKeyFile=/etc/webhook/certs/key.pem
+          ports:
+            - containerPort: {{ .Values.webhookService.targetPort }}
+          volumeMounts:
+            - name: webhook-certs
+              mountPath: /etc/webhook/certs
+              readOnly: true
+          env:
+            - name: AWS-SIGV4-PROXY-IMAGE
+              value: {{ .Values.env.awsSigV4ProxyImage }}
+      volumes:
+        - name: webhook-certs
+          secret:
+            secretName: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-webhook-certs

--- a/helm/aws-sigv4-proxy-admission-controller/templates/rbac.yaml
+++ b/helm/aws-sigv4-proxy-admission-controller/templates/rbac.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-role
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "aws-sigv4-proxy-admission-controller.labels" . | indent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [get, list]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-rolebinding
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "aws-sigv4-proxy-admission-controller.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "aws-sigv4-proxy-admission-controller.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/helm/aws-sigv4-proxy-admission-controller/templates/service.yaml
+++ b/helm/aws-sigv4-proxy-admission-controller/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-webhook-service
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}
+{{ include "aws-sigv4-proxy-admission-controller.labels" . | indent 4 }}
+spec:
+  ports:
+    - port: {{ .Values.webhookService.port }}
+      targetPort: {{ .Values.webhookService.targetPort }}
+  selector:
+    app: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}

--- a/helm/aws-sigv4-proxy-admission-controller/templates/serviceaccount.yaml
+++ b/helm/aws-sigv4-proxy-admission-controller/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "aws-sigv4-proxy-admission-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "aws-sigv4-proxy-admission-controller.labels" . | indent 4 }}
+{{- end -}}

--- a/helm/aws-sigv4-proxy-admission-controller/templates/webhook.yaml
+++ b/helm/aws-sigv4-proxy-admission-controller/templates/webhook.yaml
@@ -1,0 +1,41 @@
+{{ $tls := fromYaml ( include "aws-sigv4-proxy-admission-controller.gen-certs" . ) }}
+---
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else }}
+apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-webhook-config
+  labels:
+    app: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}
+{{ include "aws-sigv4-proxy-admission-controller.labels" . | indent 4 }}
+webhooks:
+  - name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}.k8s.aws
+    clientConfig:
+      service:
+        name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-webhook-service
+        namespace: {{ .Release.Namespace }}
+        path: "/mutate"
+      caBundle: {{ $tls.caCert }}
+    rules:
+      - operations: [ "CREATE" ]
+        apiGroups: ["apps", ""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+    sideEffects: None
+    admissionReviewVersions:
+    - v1beta1
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "aws-sigv4-proxy-admission-controller.fullname" . }}-webhook-certs
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "aws-sigv4-proxy-admission-controller.labels" . | indent 4 }}
+type: Opaque
+data:
+  cert.pem: {{ $tls.clientCert }}
+  key.pem: {{ $tls.clientKey }}

--- a/helm/aws-sigv4-proxy-admission-controller/values.yaml
+++ b/helm/aws-sigv4-proxy-admission-controller/values.yaml
@@ -1,0 +1,35 @@
+# nameOverride: Used to override name of chart
+nameOverride: ""
+# fullnameOverride: Used to override the full name of the application
+fullnameOverride: ""
+
+# replicaCount: Number of replicas
+replicaCount: 1
+
+image:
+  # image.repository: Repository of image to pull for deployment
+  repository: public.ecr.aws/aws-observability/aws-sigv4-proxy-admission-controller
+  # image.tag: Tag of image to pull from repository
+  tag: "1.0"
+  # image.pullPolicy: Policy of how to pull image
+  pullPolicy: IfNotPresent
+
+env:
+  # env.awsSigV4ProxyImage: Image URI of sidecar container for AWS SIGv4 Proxy
+  awsSigV4ProxyImage: public.ecr.aws/aws-observability/aws-sigv4-proxy:1.0
+
+serviceAccount:
+  # serviceAccount.create: Whether to create a service account or not
+  create: true
+  # serviceAccount.name: The name of the service account to create or use
+  name: ""
+
+rbac:
+  # rbac.create: Whether to create rbac resources or not
+  create: true
+
+webhookService:
+  # webhookService.port: Incoming port used by webhook service
+  port: 443
+  # webhookService.targetPort: Target port used by webhook service
+  targetPort: 443


### PR DESCRIPTION
Issue #, if available:

Description of changes:

- Add Helm chart from `eks-charts` repository
  - This chart should be published from this repository primarily due to 2 reasons:
    1. To deploy new versions of `aws-sigv4-proxy-admission-controller` artifacts in unison - both the image and the helm chart
    2. It is where the maintainers primarily operate and where users should come for feature requests, bugs/issues, documentation, etc.
    
The container image is already being published to Public ECR, the same should be done for the Helm chart which then allows both the image and the chart to be published together to Public ECR

We have opened a PR on the `eks-charts` repo to deprecate and remove this chart and direct users to this project going forward - https://github.com/aws/eks-charts/pull/1170

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.